### PR TITLE
Catch errors in compileOneFileLater

### DIFF
--- a/MelteCompiler.js
+++ b/MelteCompiler.js
@@ -204,6 +204,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
       file.addJavaScript({
         path: file.getPathInPackage()
       }, async () => {
+       try {
         const { js, css } = await getResult();
 
         if (css) {
@@ -211,6 +212,7 @@ SvelteCompiler = class SvelteCompiler extends CachingCompiler {
         }
 
         return js;
+       } catch(e) {};
       });
     }
   }


### PR DESCRIPTION
This prevents destructuring errors when `getResult` returns undefined. Merely catching the error is enough as an error is displayed to the user with the cause of it.